### PR TITLE
Remove top app bar from layout

### DIFF
--- a/spec/layout/contextual_actions_spec.cr
+++ b/spec/layout/contextual_actions_spec.cr
@@ -2,9 +2,6 @@ require "../spec_helper"
 
 module Crumble::Material::Layout::ContextualActionsSpec
   class MyLayout < Crumble::Material::Layout
-    def contextual_actions
-      [MyXAction.new, MyYAction.new]
-    end
   end
 
   class MyXAction
@@ -23,6 +20,7 @@ module Crumble::Material::Layout::ContextualActionsSpec
     it "should return the correct HTML" do
       ctx = test_handler_context
       layout = MyLayout.new(ctx: ctx)
+      contextual_actions = [MyXAction.new, MyYAction.new]
 
       stimulus_uri = Crumble::StimulusControllers.uri_path
       icon_style = Crumble::Material::Icon::Style.uri_path
@@ -80,8 +78,13 @@ module Crumble::Material::Layout::ContextualActionsSpec
       </html>
       HTML
 
-      layout.to_html do
-        nil
+      layout.to_html do |io, indent_level|
+        Crumble::Material::TopAppBar.new(
+          leading_icon: Crumble::Material::NavigationDrawer::MenuSwitch,
+          headline: nil,
+          trailing_icons: contextual_actions,
+          type: Crumble::Material::TopAppBar::Type::CenterAligned
+        ).to_html(io, indent_level)
       end.should eq(expected)
     end
   end

--- a/spec/layout/drawer_items_spec.cr
+++ b/spec/layout/drawer_items_spec.cr
@@ -90,17 +90,6 @@ module Crumble::Material::Layout::DrawerItemsSpec
             </ul>
           </nav>
           <div class="crumble--material--classes--content">
-            <nav id="crumble--material--top-app-bar--top-app-bar-id" class="crumble--material--top-app-bar--center-aligned-type">
-              <div class="crumble--material--top-app-bar--leading-icon">
-                <span data-action="click->crumble--material--menu#switch">
-                  <div class="crumble--material--icon--wrapper">
-                    <span class="crumble--material--icon--icon-class">Menu</span>
-                  </div>
-                </span>
-              </div>
-              <h1></h1>
-              <div class="crumble--material--top-app-bar--trailing-icons"></div>
-            </nav>
             <div>Hulk</div>
           </div>
         </body>

--- a/src/layout.cr
+++ b/src/layout.cr
@@ -15,8 +15,6 @@ class Crumble::Material::Layout < ToHtml::Layout
     super do
       navigation_drawer
       div Classes::Content do
-        top_app_bar
-
         yield
       end
     end
@@ -29,29 +27,8 @@ class Crumble::Material::Layout < ToHtml::Layout
     )
   end
 
-  def top_app_bar
-    Crumble::Material::TopAppBar.new(
-      leading_icon: Crumble::Material::NavigationDrawer::MenuSwitch,
-      headline: headline,
-      trailing_icons: contextual_actions || [] of Nil,
-      type: top_app_bar_type
-    )
-  end
-
   def window_title
     nil
-  end
-
-  def headline
-    nil
-  end
-
-  def contextual_actions
-    nil
-  end
-
-  def top_app_bar_type
-    TopAppBar::Type::CenterAligned
   end
 
   def drawer_headline


### PR DESCRIPTION
It is to be added by the individual views instead. Forwarding all the parameters through the layout instance wasn't practical.